### PR TITLE
Feature/cherry pick message stream functionality

### DIFF
--- a/src/Postmark.Tests/ClientMessageStreamTests.cs
+++ b/src/Postmark.Tests/ClientMessageStreamTests.cs
@@ -1,0 +1,160 @@
+﻿using Xunit;
+using PostmarkDotNet;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Postmark.Model.MessageStreams;
+using PostmarkDotNet.Model;
+
+namespace Postmark.Tests
+{
+    public class ClientMessageStreamTests : ClientBaseFixture, IDisposable
+    {
+        private PostmarkAdminClient _adminClient;
+        private PostmarkServer _server;
+
+        protected override void Setup()
+        {
+            _adminClient = new PostmarkAdminClient(WRITE_ACCOUNT_TOKEN, BASE_URL);
+            _server = TestUtils.MakeSynchronous(() => _adminClient.CreateServerAsync($"integration-test-message-stream-{Guid.NewGuid()}"));
+            _client = new PostmarkClient(_server.ApiTokens.First(), BASE_URL);
+        }
+
+        [Fact]
+        public async Task ClientCanCreateMessageStream()
+        {
+            var id = "test-id";
+            var streamType = MessageStreamType.Broadcasts;
+            var streamName = "Test Stream";
+            var description = "This is a description.";
+
+            var messageStream = await _client.CreateMessageStream(id, streamType, streamName, description);
+
+            Assert.Equal(id, messageStream.ID);
+            Assert.Equal(_server.ID, messageStream.ServerID);
+            Assert.Equal(streamType, messageStream.MessageStreamType);
+            Assert.Equal(streamName, messageStream.Name);
+            Assert.Equal(description, messageStream.Description);
+            Assert.Null(messageStream.UpdatedAt);
+            Assert.Null(messageStream.ArchivedAt);
+        }
+
+        [Fact]
+        public async Task ClientCanEditMessageStream()
+        {
+            var messageStream = await CreateDummyMessageStream(MessageStreamType.Broadcasts);
+
+            var newName = "Updated Stream Name";
+            var newDescription = "Updated Stream Description";
+            var updatedMessageStream = await _client.EditMessageStream(messageStream.ID, newName, newDescription);
+
+            Assert.Equal(newName, updatedMessageStream.Name);
+            Assert.Equal(newDescription, updatedMessageStream.Description);
+            Assert.NotNull(updatedMessageStream.UpdatedAt);
+        }
+
+        [Fact]
+        public async Task ClientCanGetMessageStream()
+        {
+            var expectedMessageStream = await CreateDummyMessageStream(MessageStreamType.Broadcasts);
+            var actualMessageStream = await _client.GetMessageStream(expectedMessageStream.ID);
+
+            Assert.Equal(expectedMessageStream.ID, actualMessageStream.ID);
+            Assert.Equal(expectedMessageStream.ServerID, actualMessageStream.ServerID);
+            Assert.Equal(expectedMessageStream.MessageStreamType, actualMessageStream.MessageStreamType);
+            Assert.Equal(expectedMessageStream.Name, actualMessageStream.Name);
+            Assert.Equal(expectedMessageStream.Description, actualMessageStream.Description);
+        }
+
+        [Fact]
+        public async Task ClientCanListMessageStreams()
+        {
+            var transactionalStream = await CreateDummyMessageStream(MessageStreamType.Transactional);
+            var broadcastsStream = await CreateDummyMessageStream(MessageStreamType.Broadcasts);
+
+            // Listing All stream types
+            var listing = await _client.ListMessageStreams(MessageStreamTypeFilter.All);
+            Assert.Equal(4, listing.TotalCount); // includes the default streams
+            Assert.Equal(4, listing.MessageStreams.Count());
+            Assert.Contains(transactionalStream.ID, listing.MessageStreams.Select(k => k.ID));
+            Assert.Contains(broadcastsStream.ID, listing.MessageStreams.Select(k => k.ID));
+
+            // Filtering by stream type
+            var filteredListing = await _client.ListMessageStreams(MessageStreamTypeFilter.Transactional);
+            Assert.Equal(2, filteredListing.TotalCount); // includes default stream
+            Assert.Equal(2, filteredListing.MessageStreams.Count());
+            Assert.Contains(transactionalStream.ID, listing.MessageStreams.Select(k => k.ID));
+        }
+
+        [Fact]
+        public async Task ClientCanListArchivedStreams()
+        {
+            var transactionalStream = await CreateDummyMessageStream(MessageStreamType.Broadcasts);
+
+            await _client.ArchiveMessageStream(transactionalStream.ID);
+
+            // By default we are not including archived streams
+            var filteredListing = await _client.ListMessageStreams(MessageStreamTypeFilter.Broadcasts, includeArchivedStreams: false);
+            Assert.Equal(0, filteredListing.TotalCount);
+            Assert.Empty(filteredListing.MessageStreams);
+
+            // Including archived streams
+            var completeListing = await _client.ListMessageStreams(MessageStreamTypeFilter.Broadcasts, includeArchivedStreams: true);
+            Assert.Equal(1, completeListing.TotalCount);
+            Assert.Single(completeListing.MessageStreams);
+            Assert.Equal(transactionalStream.ID, completeListing.MessageStreams.First().ID);
+            Assert.NotNull(completeListing.MessageStreams.First().ArchivedAt);
+        }
+
+        [Fact]
+        public async Task ClientCanArchiveStreams()
+        {
+            var transactionalStream = await CreateDummyMessageStream(MessageStreamType.Transactional);
+
+            var confirmation = await _client.ArchiveMessageStream(transactionalStream.ID);
+
+            Assert.Equal(transactionalStream.ID, confirmation.ID);
+            Assert.Equal(transactionalStream.ServerID, confirmation.ServerID);
+            Assert.True(confirmation.ExpectedPurgeDate > DateTime.UtcNow);
+
+            var fetchedMessageStream = await _client.GetMessageStream(transactionalStream.ID);
+            Assert.NotNull(fetchedMessageStream.ArchivedAt);
+        }
+
+        [Fact]
+        public async Task ClientCanUnArchiveStreams()
+        {
+            var transactionalStream = await CreateDummyMessageStream(MessageStreamType.Transactional);
+
+            await _client.ArchiveMessageStream(transactionalStream.ID);
+
+            var unarchivedStream = await _client.UnArchiveMessageStream(transactionalStream.ID);
+
+            Assert.Equal(transactionalStream.ID, unarchivedStream.ID);
+            Assert.Equal(transactionalStream.ServerID, unarchivedStream.ServerID);
+            Assert.Null(unarchivedStream.ArchivedAt);
+        }
+
+        private async Task<PostmarkMessageStream> CreateDummyMessageStream(MessageStreamType streamType)
+        {
+            var id = $"test-{Guid.NewGuid().ToString().Substring(0, 25)}"; // IDs are only 30 characters long.
+            var streamName = "Dummy Test Stream";
+            var description = "This is a dummy description.";
+
+            return await _client.CreateMessageStream(id, streamType, streamName, description);
+        }
+
+        private Task Cleanup()
+        {
+            return Task.Run(async () =>
+            {
+                await _adminClient.DeleteServerAsync(_server.ID);
+            });
+        }
+
+        public void Dispose()
+        {
+            Cleanup().Wait();
+        }
+    }
+}

--- a/src/Postmark.Tests/ClientSendingTests.cs
+++ b/src/Postmark.Tests/ClientSendingTests.cs
@@ -54,11 +54,13 @@ namespace Postmark.Tests
             var message = ConstructMessage(inboundAddress, 0, null);
             message.MessageStream = "outbound";
 
+            // Testing the default transactional stream
             var result = await _client.SendMessageAsync(message);
             Assert.Equal(PostmarkStatus.Success, result.Status);
             Assert.Equal(0, result.ErrorCode);
             Assert.NotEqual(Guid.Empty, result.MessageID);
 
+            // Testing an invalid non-existing stream
             message.MessageStream = "unknown-stream";
 
             await Assert.ThrowsAsync<PostmarkValidationException>(() => _client.SendMessageAsync(message));

--- a/src/Postmark.Tests/ClientSendingTests.cs
+++ b/src/Postmark.Tests/ClientSendingTests.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
+using PostmarkDotNet.Exceptions;
 
 namespace Postmark.Tests
 {
@@ -45,7 +47,24 @@ namespace Postmark.Tests
             Assert.NotEqual(Guid.Empty, result.MessageID);
         }
 
-        private PostmarkMessage ConstructMessage(string inboundAddress, int number = 0)
+        [Fact]
+        public async void UnknownMessageStream_ThrowsException()
+        {
+            var inboundAddress = (await _client.GetServerAsync()).InboundAddress;
+            var message = ConstructMessage(inboundAddress, 0, null);
+            message.MessageStream = "outbound";
+
+            var result = await _client.SendMessageAsync(message);
+            Assert.Equal(PostmarkStatus.Success, result.Status);
+            Assert.Equal(0, result.ErrorCode);
+            Assert.NotEqual(Guid.Empty, result.MessageID);
+
+            message.MessageStream = "unknown-stream";
+
+            await Assert.ThrowsAsync<PostmarkValidationException>(() => _client.SendMessageAsync(message));
+        }
+
+        private PostmarkMessage ConstructMessage(string inboundAddress, int number = 0, LinkTrackingOptions? trackLinks = LinkTrackingOptions.HtmlAndText)
         {
             var message = new PostmarkMessage()
             {

--- a/src/Postmark.Tests/ClientTemplateTests.cs
+++ b/src/Postmark.Tests/ClientTemplateTests.cs
@@ -125,7 +125,7 @@ namespace Postmark.Tests
         public async void ClientCanSendWithTemplate()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, PostmarkMessageBase.DefaultTransactionalStream, false);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 
@@ -152,7 +152,7 @@ namespace Postmark.Tests
         public async void ClientCanSendTemplateWithStringModel()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, PostmarkMessageBase.DefaultTransactionalStream, false);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 

--- a/src/Postmark.Tests/ClientTemplateTests.cs
+++ b/src/Postmark.Tests/ClientTemplateTests.cs
@@ -125,7 +125,8 @@ namespace Postmark.Tests
         public async void ClientCanSendWithTemplate()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, 
+                WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 
@@ -152,7 +153,8 @@ namespace Postmark.Tests
         public async void ClientCanSendTemplateWithStringModel()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", 
+                WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 

--- a/src/Postmark.Tests/ClientTemplateTests.cs
+++ b/src/Postmark.Tests/ClientTemplateTests.cs
@@ -125,7 +125,7 @@ namespace Postmark.Tests
         public async void ClientCanSendWithTemplate()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, PostmarkMessageBase.DefaultTransactionalStream, false);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 
@@ -152,7 +152,7 @@ namespace Postmark.Tests
         public async void ClientCanSendTemplateWithStringModel()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, PostmarkMessageBase.DefaultTransactionalStream, false);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 

--- a/src/Postmark.Tests/ClientTemplateTests.cs
+++ b/src/Postmark.Tests/ClientTemplateTests.cs
@@ -125,8 +125,7 @@ namespace Postmark.Tests
         public async void ClientCanSendWithTemplate()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, 
-                WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 
@@ -153,8 +152,7 @@ namespace Postmark.Tests
         public async void ClientCanSendTemplateWithStringModel()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", 
-                WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 

--- a/src/Postmark/Model/MessageStreams/MessageStreamType.cs
+++ b/src/Postmark/Model/MessageStreams/MessageStreamType.cs
@@ -1,0 +1,12 @@
+﻿namespace Postmark.Model.MessageStreams
+{
+    /// <summary>
+    /// Valid types for a message stream.
+    /// </summary>
+    public enum MessageStreamType
+    {
+        Transactional = 0,
+        Inbound = 1,
+        Broadcasts = 2
+    }
+}

--- a/src/Postmark/Model/MessageStreams/MessageStreamTypeFilter.cs
+++ b/src/Postmark/Model/MessageStreams/MessageStreamTypeFilter.cs
@@ -1,0 +1,10 @@
+﻿namespace Postmark.Model.MessageStreams
+{
+    /// <summary>
+    /// Valid values for filtering message streams by type.
+    /// </summary>
+    public enum MessageStreamTypeFilter
+    {
+        Transactional, Inbound, Broadcasts, All
+    }
+}

--- a/src/Postmark/Model/MessageStreams/PostmarkMessageStream.cs
+++ b/src/Postmark/Model/MessageStreams/PostmarkMessageStream.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Postmark.Model.MessageStreams
+{
+    /// <summary>
+    /// Model representing a message stream.
+    /// For more information about the MessageStreams API, please visit our API documentation.
+    /// </summary>
+    public class PostmarkMessageStream
+    {
+        /// <summary>
+        /// User defined identifier for this message stream that is unique at the server level.
+        /// </summary>
+        public string ID { get; set; }
+
+        /// <summary>
+        /// Id of the server this stream belongs to.
+        /// </summary>
+        public int ServerID { get; set; }
+
+        /// <summary>
+        /// Friendly name of the message stream.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Friendly description of the message stream.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The type of this message Stream. Can be Transactional, Inbound or Broadcasts.
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public MessageStreamType MessageStreamType { get; set; }
+
+        /// <summary>
+        /// The date when the message stream was created.
+        /// </summary>
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// The date when the message stream was last updated. If null, this message stream was never updated.
+        /// </summary>
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTime? UpdatedAt { get; set; }
+
+        /// <summary>
+        /// The date when this message stream has been archived. If null, this message stream is not in an archival state.
+        /// </summary>
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTime? ArchivedAt { get; set; }
+    }
+}

--- a/src/Postmark/Model/MessageStreams/PostmarkMessageStreamArchivalConfirmation.cs
+++ b/src/Postmark/Model/MessageStreams/PostmarkMessageStreamArchivalConfirmation.cs
@@ -13,7 +13,7 @@ namespace Postmark.Model.MessageStreams
         public string ID { get; set; }
 
         /// <summary>
-        /// SeverID of the message stream that was archived.
+        /// Id of the server where this stream was archived.
         /// </summary>
         public int ServerID { get; set; }
 

--- a/src/Postmark/Model/MessageStreams/PostmarkMessageStreamArchivalConfirmation.cs
+++ b/src/Postmark/Model/MessageStreams/PostmarkMessageStreamArchivalConfirmation.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Postmark.Model.MessageStreams
+{
+    /// <summary>
+    /// Confirmation of archiving a message stream.
+    /// </summary>
+    public class PostmarkMessageStreamArchivalConfirmation
+    {
+        /// <summary>
+        /// Identifier of the message stream that was archived.
+        /// </summary>
+        public string ID { get; set; }
+
+        /// <summary>
+        /// SeverID of the message stream that was archived.
+        /// </summary>
+        public int ServerID { get; set; }
+
+        /// <summary>
+        /// Expected date when this archived message stream will be removed, alongside associated content.
+        /// The stream can be unarchived up until this date.
+        /// </summary>
+        public DateTime ExpectedPurgeDate { get; set; }
+    }
+}

--- a/src/Postmark/Model/MessageStreams/PostmarkMessageStreamListing.cs
+++ b/src/Postmark/Model/MessageStreams/PostmarkMessageStreamListing.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace Postmark.Model.MessageStreams
+{
+    /// <summary>
+    /// List of message streams
+    /// </summary>
+    public class PostmarkMessageStreamListing
+    {
+        public IEnumerable<PostmarkMessageStream> MessageStreams { get; set; }
+
+        /// <summary>
+        /// Count of total message streams
+        /// </summary>
+        public int TotalCount { get; set; }
+    }
+}

--- a/src/Postmark/Model/PostmarkMessage.cs
+++ b/src/Postmark/Model/PostmarkMessage.cs
@@ -32,7 +32,7 @@ namespace PostmarkDotNet
             TextBody = textBody;
             HtmlBody = htmlBody;
             Headers = headers ?? new HeaderCollection();
-            MessageStream = messageStream ?? DefaultTransactionalStream;
+            MessageStream = messageStream;
         }
 
         /// <summary>

--- a/src/Postmark/Model/PostmarkMessage.cs
+++ b/src/Postmark/Model/PostmarkMessage.cs
@@ -21,8 +21,9 @@ namespace PostmarkDotNet
         /// <param name="textBody">The Plain Text Body to be used for the message, this may be null if HtmlBody is set.</param>
         /// <param name="htmlBody">The HTML Body to be used for the message, this may be null if TextBody is set.</param>
         /// <param name = "headers">A collection of additional mail headers to send with the message. (optional)</param>
-        public PostmarkMessage(string from, string to, string subject, string textBody, string htmlBody, HeaderCollection headers = null)
-            : base()
+        /// <param name="messageStream">The message stream used to send this message. If not provided, the default transactional stream "outbound" will be used. (optional)</param>
+        public PostmarkMessage(string from, string to, string subject, string textBody, string htmlBody,
+            HeaderCollection headers = null, string messageStream = null) : base()
         {
             
             From = from;
@@ -31,6 +32,7 @@ namespace PostmarkDotNet
             TextBody = textBody;
             HtmlBody = htmlBody;
             Headers = headers ?? new HeaderCollection();
+            MessageStream = messageStream ?? DefaultTransactionalStream;
         }
 
         /// <summary>

--- a/src/Postmark/Model/PostmarkMessageBase.cs
+++ b/src/Postmark/Model/PostmarkMessageBase.cs
@@ -11,11 +11,6 @@ namespace PostmarkDotNet
     public abstract class PostmarkMessageBase
     {
         /// <summary>
-        /// The default transactional stream available on each server.
-        /// </summary>
-        public static readonly string DefaultTransactionalStream = "outbound";
-
-        /// <summary>
         ///   Initializes a new instance of the <see cref = "PostmarkMessage" /> class.
         /// </summary>
         public PostmarkMessageBase()
@@ -27,7 +22,7 @@ namespace PostmarkDotNet
         /// <summary>
         ///   The message stream used to send this message.
         /// </summary>
-        public string MessageStream { get; set; } = DefaultTransactionalStream;
+        public string MessageStream { get; set; }
 
         /// <summary>
         ///   The sender's email address.

--- a/src/Postmark/Model/PostmarkMessageBase.cs
+++ b/src/Postmark/Model/PostmarkMessageBase.cs
@@ -11,6 +11,11 @@ namespace PostmarkDotNet
     public abstract class PostmarkMessageBase
     {
         /// <summary>
+        /// The default transactional stream available on each server.
+        /// </summary>
+        public static readonly string DefaultTransactionalStream = "outbound";
+
+        /// <summary>
         ///   Initializes a new instance of the <see cref = "PostmarkMessage" /> class.
         /// </summary>
         public PostmarkMessageBase()
@@ -18,6 +23,11 @@ namespace PostmarkDotNet
             Attachments = new List<PostmarkMessageAttachment>(0);
             TrackLinks = LinkTrackingOptions.None;
         }
+
+        /// <summary>
+        ///   The message stream used to send this message.
+        /// </summary>
+        public string MessageStream { get; set; } = DefaultTransactionalStream;
 
         /// <summary>
         ///   The sender's email address.

--- a/src/Postmark/Postmark.csproj
+++ b/src/Postmark/Postmark.csproj
@@ -6,7 +6,7 @@
     <PackageIconUrl>https://github.com/wildbit/postmark-dotnet/raw/master/postmark-logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/wildbit/postmark-dotnet.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>3.0.5</Version>
+    <Version>3.0.6</Version>
     <Company>Wildbit, LLC.</Company>
     <Description>The official .net client for Postmark.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -957,7 +957,7 @@ namespace PostmarkDotNet
                 email.TemplateAlias = (string)templateReference;
             }
             email.TemplateModel = templateModel;
-            email.MessageStream = messageStream ?? PostmarkMessageBase.DefaultTransactionalStream;
+            email.MessageStream = messageStream;
             email.To = to;
             email.From = from;
             if (inlineCss.HasValue)

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Postmark.Model.MessageStreams;
 using Postmark.Model.Suppressions;
 
 namespace PostmarkDotNet
@@ -1058,6 +1059,104 @@ namespace PostmarkDotNet
             var apiUrl = $"/message-streams/{messageStreamID}/suppressions/delete";
 
             return await ProcessRequestAsync<Dictionary<string, object>, PostmarkSuppressionBulkRequestResult>(apiUrl, HttpMethod.Post, body);
+        }
+
+        #endregion
+
+        #region MessageStreams
+
+        /// <summary>
+        /// Create a new message stream on your server.
+        /// </summary>
+        /// <param name="id">Identifier for your message stream, unique at server level.</param>
+        /// <param name="type">Type of the message stream. E.g.: Transactional or Broadcasts.</param>
+        /// <param name="name">Friendly name for your message stream.</param>
+        /// <param name="description">Friendly description for your message stream. (optional)</param>
+        /// <remarks>Currently, you cannot create multiple inbound streams.</remarks>
+        public async Task<PostmarkMessageStream> CreateMessageStream(string id, MessageStreamType type, string name, string description = null)
+        {
+            var body = new Dictionary<string, object>
+            {
+                ["ID"] = id,
+                ["Name"] = name,
+                ["Description"] = description,
+                ["MessageStreamType"] = type.ToString()
+            };
+
+            var apiUrl = "/message-streams/";
+
+            return await ProcessRequestAsync<Dictionary<string, object>, PostmarkMessageStream>(apiUrl, HttpMethod.Post, body);
+        }
+
+        /// <summary>
+        /// Edit the properties of a message stream.
+        /// </summary>
+        /// <param name="id">The identifier for the stream you are trying to update.</param>
+        /// <param name="name">New friendly name to use. (optional)</param>
+        /// <param name="description">New description to use. (optional)</param>
+        public async Task<PostmarkMessageStream> EditMessageStream(string id, string name = null, string description = null)
+        {
+            var body = new Dictionary<string, object>
+            {
+                ["Name"] = name,
+                ["Description"] = description
+            };
+
+            var apiUrl = $"/message-streams/{id}";
+
+            return await ProcessRequestAsync<Dictionary<string, object>, PostmarkMessageStream>(apiUrl, new HttpMethod("PATCH"), body);
+        }
+
+        /// <summary>
+        /// Retrieve details about a message stream.
+        /// </summary>
+        /// <param name="id">Identifier of the stream to retrieve details for.</param>
+        public async Task<PostmarkMessageStream> GetMessageStream(string id)
+        {
+            return await ProcessNoBodyRequestAsync<PostmarkMessageStream>($"/message-streams/{id}");
+        }
+
+        /// <summary>
+        /// Retrieve all message streams on the server.
+        /// </summary>
+        /// <param name="messageStreamType">Filter by stream type. E.g.: Transactional. Defaults to: All.</param>
+        /// <param name="includeArchivedStreams">Include archived streams in the result. Defaults to: false.</param>
+        public async Task<PostmarkMessageStreamListing> ListMessageStreams(MessageStreamTypeFilter messageStreamType = MessageStreamTypeFilter.All,
+            bool includeArchivedStreams = false)
+        {
+            var parameters = new Dictionary<string, object>
+            {
+                ["MessageStreamType"] = messageStreamType.ToString(),
+                ["IncludeArchivedStreams"] = includeArchivedStreams
+            };
+
+            return await ProcessNoBodyRequestAsync<PostmarkMessageStreamListing>("/message-streams/", parameters);
+        }
+
+        /// <summary>
+        /// Archive a message stream. This will disable sending/receiving messages via that stream.
+        /// The stream will also stop being shown in the Postmark UI.
+        /// Once a stream has been archived, it will be deleted (alongside associated data) at the ExpectedPurgeDate in the response.
+        /// </summary>
+        /// <param name="id">Identifier of the stream to archive.</param>
+        public async Task<PostmarkMessageStreamArchivalConfirmation> ArchiveMessageStream(string id)
+        {
+            var apiUrl = $"/message-streams/{id}/archive";
+
+            return await ProcessNoBodyRequestAsync<PostmarkMessageStreamArchivalConfirmation>(apiUrl, verb: HttpMethod.Post);
+        }
+
+        /// <summary>
+        /// UnArchive a message stream. This will resume sending/receiving via that stream.
+        /// The stream will also re-appear in the Postmark UI.
+        /// A stream can be unarchived only before the stream ExpectedPurgeDate.
+        /// </summary>
+        /// <param name="id">Identifier of the stream to unArchive.</param>
+        public async Task<PostmarkMessageStream> UnArchiveMessageStream(string id)
+        {
+            var apiUrl = $"/message-streams/{id}/unarchive";
+
+            return await ProcessNoBodyRequestAsync<PostmarkMessageStream>(apiUrl, verb: HttpMethod.Post);
         }
 
         #endregion

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -916,37 +916,37 @@ namespace PostmarkDotNet
 
         public async Task<PostmarkResponse> SendEmailWithTemplateAsync<T>(string templateAlias, T templateModel,
             string to, string from,
-            string messageStream = null,
             bool? inlineCss = null, string cc = null,
             string bcc = null, string replyTo = null,
             bool? trackOpens = null,
             IDictionary<string, string> headers = null,
+            string messageStream = null,
             params PostmarkMessageAttachment[] attachments)
         {
-            return await InternalSendEmailWithTemplateAsync(templateAlias, templateModel, messageStream, to, from, inlineCss, cc,
-            bcc, replyTo, trackOpens, headers, attachments);
+            return await InternalSendEmailWithTemplateAsync(templateAlias, templateModel, to, from, inlineCss, cc,
+            bcc, replyTo, trackOpens, headers, messageStream, attachments);
         }
 
         public async Task<PostmarkResponse> SendEmailWithTemplateAsync<T>(long templateId, T templateModel,
             string to, string from,
-            string messageStream = null,
             bool? inlineCss = null, string cc = null,
             string bcc = null, string replyTo = null,
             bool? trackOpens = null,
             IDictionary<string, string> headers = null,
+            string messageStream = null,
             params PostmarkMessageAttachment[] attachments)
         {
-            return await InternalSendEmailWithTemplateAsync(templateId, templateModel, messageStream, to, from, inlineCss, cc,
-            bcc, replyTo, trackOpens, headers, attachments);
+            return await InternalSendEmailWithTemplateAsync(templateId, templateModel, to, from, inlineCss, cc,
+            bcc, replyTo, trackOpens, headers, messageStream, attachments);
         }
 
         private async Task<PostmarkResponse> InternalSendEmailWithTemplateAsync<T>(object templateReference, T templateModel,
-            string messageStream,
             string to, string from,
             bool? inlineCss = null, string cc = null,
             string bcc = null, string replyTo = null,
             bool? trackOpens = null,
             IDictionary<string, string> headers = null,
+            string messageStream = null,
             params PostmarkMessageAttachment[] attachments)
         {
             
@@ -957,7 +957,7 @@ namespace PostmarkDotNet
                 email.TemplateAlias = (string)templateReference;
             }
             email.TemplateModel = templateModel;
-            email.MessageStream = messageStream;
+            email.MessageStream = messageStream ?? PostmarkMessageBase.DefaultTransactionalStream;
             email.To = to;
             email.From = from;
             if (inlineCss.HasValue)

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -916,29 +916,32 @@ namespace PostmarkDotNet
 
         public async Task<PostmarkResponse> SendEmailWithTemplateAsync<T>(string templateAlias, T templateModel,
             string to, string from,
+            string messageStream = null,
             bool? inlineCss = null, string cc = null,
             string bcc = null, string replyTo = null,
             bool? trackOpens = null,
             IDictionary<string, string> headers = null,
             params PostmarkMessageAttachment[] attachments)
         {
-            return await InternalSendEmailWithTemplateAsync(templateAlias, templateModel, to, from, inlineCss, cc,
+            return await InternalSendEmailWithTemplateAsync(templateAlias, templateModel, messageStream, to, from, inlineCss, cc,
             bcc, replyTo, trackOpens, headers, attachments);
         }
 
         public async Task<PostmarkResponse> SendEmailWithTemplateAsync<T>(long templateId, T templateModel,
             string to, string from,
+            string messageStream = null,
             bool? inlineCss = null, string cc = null,
             string bcc = null, string replyTo = null,
             bool? trackOpens = null,
             IDictionary<string, string> headers = null,
             params PostmarkMessageAttachment[] attachments)
         {
-            return await InternalSendEmailWithTemplateAsync(templateId, templateModel, to, from, inlineCss, cc,
+            return await InternalSendEmailWithTemplateAsync(templateId, templateModel, messageStream, to, from, inlineCss, cc,
             bcc, replyTo, trackOpens, headers, attachments);
         }
 
         private async Task<PostmarkResponse> InternalSendEmailWithTemplateAsync<T>(object templateReference, T templateModel,
+            string messageStream,
             string to, string from,
             bool? inlineCss = null, string cc = null,
             string bcc = null, string replyTo = null,
@@ -954,6 +957,7 @@ namespace PostmarkDotNet
                 email.TemplateAlias = (string)templateReference;
             }
             email.TemplateModel = templateModel;
+            email.MessageStream = messageStream;
             email.To = to;
             email.From = from;
             if (inlineCss.HasValue)

--- a/src/Postmark/PostmarkClientExtensions.cs
+++ b/src/Postmark/PostmarkClientExtensions.cs
@@ -24,7 +24,7 @@ namespace PostmarkDotNet
         /// <param name="textBody">The Plain Text Body to be used for the message, this may be null if HtmlBody is set.</param>
         /// <param name="htmlBody">The HTML Body to be used for the message, this may be null if TextBody is set.</param>
         /// <param name="headers">A collection of additional mail headers to send with the message.</param>
-        /// <param name="messageStream">The message stream used to send this message</param>
+        /// <param name="messageStream">The message stream used to send this message.</param>
         /// <returns>A <see cref = "PostmarkResponse" /> with details about the transaction.</returns>
         public static async Task<PostmarkResponse> SendMessageAsync(this PostmarkClient client,
             string from, string to, string subject, string textBody, string htmlBody,

--- a/src/Postmark/PostmarkClientExtensions.cs
+++ b/src/Postmark/PostmarkClientExtensions.cs
@@ -10,7 +10,6 @@ namespace PostmarkDotNet
     /// </summary>
     public static class PostmarkClientExtensions
     {
-
         /// <summary>
         /// Sends a message through the Postmark API.
         /// All email addresses must be valid, and the sender must be
@@ -25,11 +24,15 @@ namespace PostmarkDotNet
         /// <param name="textBody">The Plain Text Body to be used for the message, this may be null if HtmlBody is set.</param>
         /// <param name="htmlBody">The HTML Body to be used for the message, this may be null if TextBody is set.</param>
         /// <param name="headers">A collection of additional mail headers to send with the message.</param>
+        /// <param name="messageStream">The message stream used to send this message</param>
         /// <returns>A <see cref = "PostmarkResponse" /> with details about the transaction.</returns>
         public static async Task<PostmarkResponse> SendMessageAsync(this PostmarkClient client,
-            string from, string to, string subject, string textBody, string htmlBody, IDictionary<string, string> headers = null)
+            string from, string to, string subject, string textBody, string htmlBody,
+             IDictionary<string, string> headers = null,
+             string messageStream = null)
         {
-            var message = new PostmarkMessage(from, to, subject, textBody, htmlBody, new HeaderCollection(headers));
+            var message = new PostmarkMessage(from, to, subject, textBody, htmlBody,
+            new HeaderCollection(headers), messageStream);
             return await client.SendMessageAsync(message);
         }
 


### PR DESCRIPTION
Cherry-picked all commits from the following PRs in order to bring support for message streams (the message stream api itself and the ability to specify messagestream in the sending api):
https://github.com/ActiveCampaign/postmark-dotnet/pull/79/commits
https://github.com/ActiveCampaign/postmark-dotnet/pull/83/commits

Tests project did not build before and does not build now. I worked with Ness to attempt to fix that and we timeboxed it, then gave up.

Tested by referencing the project directly in HRMDirect.